### PR TITLE
Removing bling

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -13,10 +13,6 @@
         },
         {
             "type": "vcs",
-            "url": "https://github.com/techfromsage/bling"
-        },
-        {
-            "type": "vcs",
             "url": "https://github.com/techfromsage/bootstrap-sass"
         },
         {


### PR DESCRIPTION
The bling library is now dead since the BL integration it uses is offline and won't be coming back. It has already been removed from DC, this PR removes it from talis.composer.io