### PR TITLE
Fix deployment to GitHub Pages on workflow dispatch

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,7 +39,7 @@ jobs:
         run: echo 'composer.talis.io' > dist/CNAME
 
       - name: Deploy to GitHub Pages
-        if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ success() && github.ref == 'refs/heads/main' }}
         uses: crazy-max/ghaction-github-pages@v4
         with:
           target_branch: gh-pages


### PR DESCRIPTION
Fixes the deployment to GitHub Pages step so it can be run by workflow dispatch, used to update the list of package versions